### PR TITLE
change the kernel size after GroupBilinear layer according to the official code

### DIFF
--- a/dbt_pytorch.py
+++ b/dbt_pytorch.py
@@ -171,7 +171,7 @@ class Bottleneck(nn.Module):
         if self.use_SG_GB:
             self.SG = GroupConv(inplanes, planes, featuremap_size, 16)
             self.GB = GroupBillinear(16, featuremap_size, planes)
-            self.conv1 = conv1x1(planes, planes)
+            self.conv1 = conv3x3(planes, planes)
         else:
             self.conv1 = conv1x1(inplanes, planes)
 


### PR DESCRIPTION
I am very interested with this work, and thank you.

I found the code  that is different with the official source code.
https://github.com/wuwusky/DBT_Net/blob/b6543eb0fac299aa8b2ba1cb4b5b0f9cf361a3e7/dbt_pytorch.py#L184
In the section 3.3 of the paper "Learning Deep Bilinear Transformation for Fine-grained Image Representation",  the author wrote that "The group biinear layer is followed by a **3x3 convolution**, ..."

Meanwhile, the official source code also shows in the [#L321](https://github.com/researchmm/DBTNet/blob/40877de074e10f84749a5f5acda0594d5c1172e0/dbt.py#L321), and the kernel size after GroupBilinear layer is **3x3**